### PR TITLE
Drop unused imports to fix flake8 errors

### DIFF
--- a/numcodecs/tests/test_gzip.py
+++ b/numcodecs/tests/test_gzip.py
@@ -7,7 +7,6 @@ import numpy as np
 
 
 from numcodecs.gzip import GZip
-from numcodecs.registry import get_codec
 from numcodecs.tests.common import (check_encode_decode, check_config, check_repr,
                                     check_backwards_compatibility,
                                     check_err_decode_object_buffer,

--- a/numcodecs/tests/test_zlib.py
+++ b/numcodecs/tests/test_zlib.py
@@ -7,7 +7,6 @@ import numpy as np
 
 
 from numcodecs.zlib import Zlib
-from numcodecs.registry import get_codec
 from numcodecs.tests.common import (check_encode_decode, check_config, check_repr,
                                     check_backwards_compatibility,
                                     check_err_decode_object_buffer,


### PR DESCRIPTION
Fixes some [flake8 errors]( https://travis-ci.org/zarr-developers/numcodecs/jobs/443961651#L1283-L1284 ) missed in PR ( https://github.com/funkey/numcodecs/pull/2 ). Hopefully this is the last of them. 🍀

xref: https://github.com/zarr-developers/numcodecs/pull/87